### PR TITLE
feat: add HLS video player with production retry config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_API_URL=http://localhost:8000
+NEXT_PUBLIC_MEDIA_URL=http://localhost:8080

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,9 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # env files (can opt-in for committing if needed)
-.env*
+.env.local
+.env.production
+.env.staging
 
 # vercel
 .vercel

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "specter-dashboard",
       "version": "0.1.0",
       "dependencies": {
+        "hls.js": "^1.6.15",
         "leaflet": "^1.9.4",
         "next": "16.2.2",
         "react": "19.2.4",
@@ -3939,6 +3940,12 @@
       "dependencies": {
         "hermes-estree": "0.25.1"
       }
+    },
+    "node_modules/hls.js": {
+      "version": "1.6.15",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.15.tgz",
+      "integrity": "sha512-E3a5VwgXimGHwpRGV+WxRTKeSp2DW5DI5MWv34ulL3t5UNmyJWCQ1KmLEHbYzcfThfXG8amBL+fCYPneGHC4VA==",
+      "license": "Apache-2.0"
     },
     "node_modules/ignore": {
       "version": "5.3.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "hls.js": "^1.6.15",
     "leaflet": "^1.9.4",
     "next": "16.2.2",
     "react": "19.2.4",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import dynamic from "next/dynamic";
 import { StatusBar } from "@/components/dashboard/status-bar";
 import { TelemetryPanel } from "@/components/dashboard/telemetry-panel";
 import { SystemLog } from "@/components/dashboard/system-log";
+import VideoPlayer from "@/components/dashboard/video-player";
 
 const DroneMap = dynamic(
   () => import("@/components/dashboard/drone-map").then(mod => ({ default: mod.DroneMap })),
@@ -11,7 +12,8 @@ const DroneMap = dynamic(
 );
 
 export default function Dashboard() {
-  const { data, status, error } = useTelemetry("drone-1");
+  const droneId = "drone-1"
+  const { data, status, error } = useTelemetry(droneId);
 
   return (
     <div className="flex flex-col gap-6">
@@ -23,7 +25,7 @@ export default function Dashboard() {
           {/* Map */}
           <div className="relative w-full aspect-[21/9] bg-surface-container-low rounded overflow-hidden">
             {data ? (
-              <DroneMap lat={data.lat} lon={data.lon} />
+              <DroneMap lat={data.lat} lon={data.lon} heading={data.heading} />
             ) : (
               <div className="flex items-center justify-center w-full h-full text-on-surface-variant/40 font-headline text-sm uppercase tracking-widest">
                 Awaiting telemetry...
@@ -34,9 +36,7 @@ export default function Dashboard() {
           {/* Feed + Log */}
           <div className="grid grid-cols-2 gap-6">
             <div className="relative bg-surface-container rounded overflow-hidden aspect-video flex items-center justify-center">
-              <span className="text-on-surface-variant/40 font-headline text-sm uppercase tracking-widest">
-                Live feed — later
-              </span>
+              <VideoPlayer droneId={droneId} />
             </div>
             <SystemLog />
           </div>

--- a/src/components/dashboard/drone-map.tsx
+++ b/src/components/dashboard/drone-map.tsx
@@ -7,15 +7,18 @@ import { useMap } from "react-leaflet";
 interface DroneMapProps {
     lat: number | 28.662876;
     lon: number | 77.343407;
+    heading: number;
 }
 
-const droneIcon = L.divIcon({
-    html: `<span class="material-symbols-outlined" style="font-size:32px;color:#4b8eff;font-variation-settings:'FILL'
-    1;">navigation</span>`,
-    className: "",
-    iconSize: [32, 32],
-    iconAnchor: [16, 16],
-})
+function createDroneIcon(heading: number) {
+    return L.divIcon({
+        html: `<span class="material-symbols-outlined" style="font-size:32px;color:#4b8eff;font-variation-settings:'FILL'
+        1;transform:rotate(${heading}deg);">navigation</span>`,
+        className: "",
+        iconSize: [32, 32],
+        iconAnchor: [16, 16],
+    });
+}
 
 function FollowDrone({ lat, lon }: { lat: number; lon: number }) {
     const map = useMap();
@@ -23,7 +26,7 @@ function FollowDrone({ lat, lon }: { lat: number; lon: number }) {
     return null;
 }
 
-export function DroneMap({ lat, lon }: DroneMapProps) {
+export function DroneMap({ lat, lon, heading }: DroneMapProps) {
     return (
 
         <MapContainer
@@ -32,7 +35,7 @@ export function DroneMap({ lat, lon }: DroneMapProps) {
             className="w-full h-full"
         >
             <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
-            <Marker position={[lat, lon]} icon={droneIcon} />
+            <Marker position={[lat, lon]} icon={createDroneIcon(heading)} />
             <FollowDrone lat={lat} lon={lon} />
         </MapContainer>
     )

--- a/src/components/dashboard/video-player.tsx
+++ b/src/components/dashboard/video-player.tsx
@@ -1,0 +1,90 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+import Hls from "hls.js"
+
+interface VideoPlayerProps {
+    droneId: string;
+}
+
+export default function VideoPlayer({ droneId }: VideoPlayerProps) {
+    const videoRef = useRef<HTMLVideoElement>(null)
+
+    useEffect(() => {
+        const video = videoRef.current
+        if (!video) return;
+
+        const streamUrl = `${process.env.NEXT_PUBLIC_MEDIA_URL}/live/${droneId}.m3u8`;
+
+        if (Hls.isSupported()) {
+            const hls = new Hls({
+                // How often to poll the playlist for new segments
+                liveSyncDurationCount: 3,        // stay 3 segments behind live edge (default)
+                liveMaxLatencyDurationCount: 6,  // if >6 segments behind, skip to live
+
+                // Retry behavior
+                manifestLoadingMaxRetry: 6,      // retry fetching playlist 6 times
+                manifestLoadingRetryDelay: 1000, // wait 1s between retries
+                levelLoadingMaxRetry: 6,         // retry fetching quality levels
+                levelLoadingRetryDelay: 1000,
+                fragLoadingMaxRetry: 6,          // retry fetching video segments
+                fragLoadingRetryDelay: 1000,
+
+                // Backoff — doubles delay each retry up to this cap
+                manifestLoadingMaxRetryTimeout: 30000,  // max 30s between retries
+                levelLoadingMaxRetryTimeout: 30000,
+                fragLoadingMaxRetryTimeout: 30000,
+
+                // Low latency tuning
+                lowLatencyMode: true,            // fetch segments as they're written
+                backBufferLength: 30,            // keep 30s of played video in buffer
+            })
+            hls.loadSource(streamUrl)
+            hls.attachMedia(video)
+            hls.on(Hls.Events.MANIFEST_PARSED, function () {
+                video.play().catch(() => { });
+            })
+            hls.on(Hls.Events.ERROR, (_event, data) => {
+                if (data.fatal) {
+                    switch (data.type) {
+                        case Hls.ErrorTypes.NETWORK_ERROR:
+                            hls.startLoad();
+                            break;
+                        case Hls.ErrorTypes.MEDIA_ERROR:
+                            hls.recoverMediaError();
+                            break;
+                        default:
+                            hls.destroy();
+                            break;
+                    }
+
+                }
+            })
+
+            return () => {
+                hls.destroy();
+            }
+        }
+
+        else if (video.canPlayType('application/vnd.apple.mpegurl')) {
+            video.src = streamUrl
+
+            const onCanPlay = () => video.play();
+            video.addEventListener('canplay', onCanPlay);
+
+            return () => {
+                video.removeEventListener('canplay', onCanPlay);
+                video.src = '';
+            }
+        }
+    }, [droneId]);
+
+    return (
+        <video
+            ref={videoRef}
+            controls
+            muted
+        // style={{ width: "100%", maxHeight: "480px" }}        
+        />
+    )
+}

--- a/src/hooks/use-telemetry.ts
+++ b/src/hooks/use-telemetry.ts
@@ -33,8 +33,8 @@ export function useTelemetry(drone_id: string) {
     const [state, dispatch] = useReducer(reducer, initialState);
 
     useEffect(() => {
-        const url = `http://localhost:8000/api/v1/stream/telemetry?drone_id=${drone_id}`;
-        const eventSource = new EventSource(url);
+        const sseUrl = `${process.env.NEXT_PUBLIC_API_URL}/api/v1/stream/telemetry?drone_id=${drone_id}`;
+        const eventSource = new EventSource(sseUrl);
 
         eventSource.onopen = () => {
             dispatch({ type: "OPEN" })


### PR DESCRIPTION
- Add VideoPlayer component using hls.js with exponential backoff retry, low latency mode, and proper cleanup on unmount
- Add .env.example with NEXT_PUBLIC_API_URL and NEXT_PUBLIC_MEDIA_URL
- Update use-telemetry hook to use env var for API URL
- Update drone-map to accept heading prop for marker rotation
- Extract droneId variable in page.tsx for telemetry + video sync
- Update .gitignore for env file patterns