### PR TITLE
feat: update video player for mediamtx HLS URL format

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
 NEXT_PUBLIC_API_URL=http://localhost:8000
-NEXT_PUBLIC_MEDIA_URL=http://localhost:8080
+NEXT_PUBLIC_MEDIA_URL=http://localhost:8888

--- a/src/components/dashboard/video-player.tsx
+++ b/src/components/dashboard/video-player.tsx
@@ -14,7 +14,7 @@ export default function VideoPlayer({ droneId }: VideoPlayerProps) {
         const video = videoRef.current
         if (!video) return;
 
-        const streamUrl = `${process.env.NEXT_PUBLIC_MEDIA_URL}/live/${droneId}.m3u8`;
+        const streamUrl = `${process.env.NEXT_PUBLIC_MEDIA_URL}/live/${droneId}/index.m3u8`;
 
         if (Hls.isSupported()) {
             const hls = new Hls({


### PR DESCRIPTION
Update HLS stream URL from /live/{droneId}.m3u8 to /live/{droneId}/index.m3u8 to match mediamtx path structure. Update media port from 8080 to 8888 in .env.example.